### PR TITLE
fix: awkward version

### DIFF
--- a/site/files/tutorial.ipynb
+++ b/site/files/tutorial.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "import piplite\n",
-    "await piplite.install(\"awkward==2.7.2\")\n",
+    "await piplite.install(\"awkward==2.7.4\")\n",
     "await piplite.install(\"hist\")\n",
     "await piplite.install(\"uproot\")\n",
     "await piplite.install(\"vector\")"

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -1,4 +1,4 @@
-jupyterlite-core
-jupyterlab
-notebook
-jupyterlite-pyodide-kernel
+jupyterlite-core==0.6.4
+jupyterlab==4.4.5
+notebook==7.4.5
+jupyterlite-pyodide-kernel==0.6.1


### PR DESCRIPTION
This is a band-aid patch on a larger problem: requesting version 2.7.2 creates a long error message about `awkward_cpp` not being a pure Python package, but version 2.7.3 and 2.7.4 work: both require `awkward_cpp==44`.

I had assumed that Pyodide would include all `awkward_cpp` versions that have ever been included in it, but apparently it only stores the latest. As new versions of Pyodide come out, they may be bundled with a newer `awkward_cpp` and then this line of code would break again.

I'm going to add to this PR to pin the Jupyter versions to the ones used in the last build:

```
jupyterlite-core==0.6.4
jupyterlab==4.4.5
notebook==7.4.5
jupyterlite-pyodide-kernel==0.6.1
```

and hope that this prevents Pyodide from updating.